### PR TITLE
CI: Add Claude review workflows from style-guide

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,51 @@
+name: claude-review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    paths-ignore:
+      - '.github/workflows/claude-review.yaml'
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+
+    if: |
+      (
+        github.event_name == 'pull_request'
+        && !github.event.pull_request.draft
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && github.actor != 'dependabot[bot]'
+      )
+      || (
+        github.event_name == 'issue_comment'
+        && github.event.issue.pull_request
+        && contains(github.event.comment.body, '/claude-review')
+        && github.event.comment.user.type != 'Bot'
+      )
+
+    permissions:
+      contents: read
+      pull-requests: read
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: veecle/style-guide/.github/actions/claude-review@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  minimize-old-claude-comments:
+    runs-on: ubuntu-latest
+    needs: review
+    if: always() && needs.review.result == 'success'
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: veecle/style-guide/.github/actions/minimize-old-claude-comments@main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+      || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+      || (
+        github.event_name == 'issues'
+        && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+      )
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: veecle/style-guide/.github/actions/claude@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## What

Wires in automated Claude Code review for this repo, using the reusable composite GitHub Actions maintained in [veecle/style-guide](https://github.com/veecle/style-guide):

- `.github/workflows/claude-review.yml` — auto-reviews PRs on open/ready-for-review, re-triggerable via `/claude-review` comment, and minimizes stale review comments on re-run. Skips drafts, forked PRs, and dependabot.
- `.github/workflows/claude.yml` — responds to `@claude` mentions in issue/PR comments and reviews.

Both call `veecle/style-guide/.github/actions/{claude-review,claude,minimize-old-claude-comments}@main` directly (not vendored), so they'll pick up upstream improvements automatically. Reviews are guided by the shared `.agents/rules/shared/{AGENTS,code-review}.md` guidelines from style-guide, run on the `opus` model (hardcoded upstream, not configurable per-repo today).

## Requirements

- `ANTHROPIC_API_KEY` repo secret — already set.

## Verification

Files copied verbatim from style-guide `main` (diffed byte-for-byte against a fresh fetch before committing). No local modifications.