### PR TITLE
Expand documentation on supported boards and frameworks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,9 @@ Examples exist to validate Chiplab end-to-end, nothing more. Keep them minimal.
   footgun).
 - **No per-example README.** Board metadata lives only in
   [supported-boards.md](supported-boards.md) — add a matrix row there for any new board.
+  [docs/hardware/boards.mdx](docs/hardware/boards.mdx) mirrors this matrix for the
+  Mintlify docs site — update its table too, in the same commit, or it will silently
+  drift out of sync.
 - **Verify** by building per the framework doc, then upload + run it on the
   matching board and confirm `Hello world!` in the captured output.
 - **Adding a framework?** Create `examples/<framework>/` with its own `README.md` +

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,7 +7,14 @@
     "groups": [
       { "group": "Get Started", "pages": ["introduction", "quickstart"] },
       { "group": "Agents", "pages": ["agents/overview", "agents/cursor", "agents/opencode", "agents/claude-code", "agents/claude-desktop", "agents/vs-code", "agents/codex"] },
-      { "group": "Tools", "pages": ["tools/overview"] },
+      {
+        "group": "Tools",
+        "pages": [
+          "tools/overview",
+          "tools/ask",
+          "tools/run"
+        ]
+      },
       { "group": "Hardware", "pages": ["hardware/boards"] },
       { "group": "Platform", "pages": ["platform/api-keys", "platform/usage"] }
     ]

--- a/docs/hardware/boards.mdx
+++ b/docs/hardware/boards.mdx
@@ -5,6 +5,41 @@ description: "Every board, chip, and framework combination Chiplab supports toda
 
 Chiplab boots a virtual instance of each supported chip on open simulation platforms — today that means [Renode](https://renode.io), with [QEMU](https://www.qemu.org) and more support planned as coverage grows — and captures the UART output for you to read back.
 
-The full board matrix — every board, its chip, its board key (the identifier your MCP client passes when starting a run), and which OS/framework examples exist for it — lives in [supported-boards.md](https://github.com/veecle/chiplab/blob/main/supported-boards.md).
+## OS / frameworks
 
-Call Chiplab's discovery/help tool (`ask`) to confirm the current, authoritative set of boards — it may be ahead of what's listed there.
+Chiplab runs the same firmware pattern across four OS/framework combinations:
+
+- **`bare-metal`** — vendor-HAL / direct-register Rust firmware (no async runtime).
+- **`embassy-rust`** — the same firmware on the [Embassy](https://embassy.dev) async runtime.
+- **`zephyr-os`** — the same firmware on the [Zephyr RTOS](https://zephyrproject.org) (C, built with `west`).
+- **`freertos`** — the same firmware on the [FreeRTOS](https://www.freertos.org) kernel (C, built with `make` + `arm-none-eabi-gcc`).
+
+## Board matrix
+
+Every board Chiplab supports today, its chip, and its **board key** — the identifier your MCP client passes when starting a run. A checkmark links to a ready-to-run example for that OS/framework (— = not available yet).
+
+| Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` |
+|---|---|---|---|---|---|---|---|
+| STM32F4 Discovery | STM32F407 | STM32F4 | `stm32f4_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f4-discovery) | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/freertos/stm32f4-discovery) |
+| STM32F7 Discovery | STM32F746 | STM32F7 | `stm32f7_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f7-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f7-discovery) | — | — |
+| STM32F103 Blue Pill | STM32F103 | STM32F1 | `stm32f103_blue_pill` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f103-blue-pill) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f103-blue-pill) | — | — |
+| STM32WBA52 Nucleo | STM32WBA52 | STM32WBA | `stm32wba52_nucleo` | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32wba52-nucleo) | — | — |
+| STM32L073 Nucleo | STM32L073 | STM32L0 | `stm32l073_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32l073-nucleo) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32l073-nucleo) | — | — |
+| STM32H745 Nucleo | STM32H745 | STM32H7 | `stm32h745_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32h745-nucleo) | — | — | — |
+| nRF52840 DK | nRF52840 | nRF52 | `nrf52840_dk` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/nrf52840-dk) | — |
+
+Call Chiplab's discovery/help tool (`ask`) to confirm the current, authoritative set of boards — it may be ahead of what's listed here.
+
+## What simulation covers
+
+Each run includes:
+
+- CPU execution of your ELF binary.
+- UART/USART/LPUART peripherals — all output is captured and returned in the run's output.
+- Peripheral registers and interrupt timing matching the physical chip.
+
+Runs are bounded to a fixed amount of virtual CPU time (not wall-clock time).
+
+## Don't see your chip?
+
+Please don't hesitate to ask — requests really do shape what we add next. [Open a request](https://github.com/veecle/chiplab/issues/new/choose) on GitHub with your target MCU and use case, and our team will review it — or come say hi on [Discord](https://discord.com/invite/F6GwZJ6ktP).

--- a/docs/hardware/boards.mdx
+++ b/docs/hardware/boards.mdx
@@ -16,7 +16,9 @@ Chiplab runs the same firmware pattern across four OS/framework combinations:
 
 ## Board matrix
 
-Every board Chiplab supports today, its chip, and its **board key** — the identifier your MCP client passes when starting a run. A checkmark links to a ready-to-run example for that OS/framework (— = not available yet).
+Every board Chiplab supports today, its chip, and its **board key** — the identifier your MCP client passes when starting a run.
+A checkmark links to a ready-to-run example for that OS/framework (— = not available yet).
+The canonical copy of this matrix lives in [supported-boards.md](https://github.com/veecle/chiplab/blob/main/supported-boards.md); if the two ever diverge, that file is authoritative.
 
 | Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` |
 |---|---|---|---|---|---|---|---|
@@ -42,4 +44,5 @@ Runs are bounded to a fixed amount of virtual CPU time (not wall-clock time).
 
 ## Don't see your chip?
 
-Please don't hesitate to ask — requests really do shape what we add next. [Open a request](https://github.com/veecle/chiplab/issues/new/choose) on GitHub with your target MCU and use case, and our team will review it — or come say hi on [Discord](https://discord.com/invite/F6GwZJ6ktP).
+Please don't hesitate to ask — requests really do shape what we add next.
+[Open a request](https://github.com/veecle/chiplab/issues/new/choose) on GitHub with your target MCU and use case, and our team will review it — or come say hi on [Discord](https://discord.com/invite/F6GwZJ6ktP).

--- a/docs/tools/ask.mdx
+++ b/docs/tools/ask.mdx
@@ -5,16 +5,20 @@ description: "Query the Chiplab firmware knowledge base tool. Ask about platform
 ---
 
 <Info>
-  This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself, just ask your agent in plain language and it takes care of the rest. This is a reference for the curious, not a set of instructions for you to follow.
+  This page describes what your AI agent can do with Chiplab.
+  You don't need to call anything yourself, just ask your agent in plain language and it takes care of the rest.
+  This is a reference for the curious, not a set of instructions for you to follow.
 </Info>
 
-The `ask` tool gives your AI agent direct access to Chiplab's built-in knowledge base. Use it to look up how the platform works, understand the available tools, discover supported boards, and get guidance on uploading and running firmware. The assistant behind `ask` is purpose-built for Chiplab and will not answer questions unrelated to the platform.
+The `ask` tool gives your AI agent direct access to Chiplab's built-in knowledge base.
+Use it to look up how the platform works, understand the available tools, discover supported boards, and get guidance on uploading and running firmware.
+The assistant behind `ask` is purpose-built for Chiplab and will not answer questions unrelated to the platform.
 
 Exact parameters may evolve as the platform grows — call `ask({ "query": null })` to confirm the current shape.
 
 ## Parameters
 
-<ParamField query="query" type="string | null">
+<ParamField body="query" type="string | null">
   A natural language question about Chiplab, or `null` to receive a platform overview describing what Chiplab does and listing all available tools.
 </ParamField>
 
@@ -25,7 +29,8 @@ Exact parameters may evolve as the platform grows — call `ask({ "query": null 
 </ResponseField>
 
 <Note>
-  Every Chiplab session should start with `ask({ "query": null })`. It gives your agent the context it needs before uploading or running firmware.
+  Every Chiplab session should start with `ask({ "query": null })`.
+  It gives your agent the context it needs before uploading or running firmware.
 </Note>
 
 ## Example calls
@@ -50,4 +55,6 @@ Discover which boards are available for simulation:
 
 ## How it works
 
-When you call `ask` with a `null` query, Chiplab returns a platform overview directly from its knowledge base. When you pass a natural language question, Chiplab routes it to an AI assistant with access to the most relevant sections of the shared [knowledge corpus](/introduction#knowledge-corpus) and composes a focused answer. The assistant is scoped exclusively to Chiplab usage topics, so every answer is grounded in accurate, up-to-date platform documentation.
+When you call `ask` with a `null` query, Chiplab returns a platform overview directly from its knowledge base.
+When you pass a natural language question, Chiplab routes it to an AI assistant with access to the most relevant sections of the shared [knowledge corpus](/introduction#knowledge-corpus) and composes a focused answer.
+The assistant is scoped exclusively to Chiplab usage topics, so every answer is grounded in accurate, up-to-date platform documentation.

--- a/docs/tools/ask.mdx
+++ b/docs/tools/ask.mdx
@@ -1,0 +1,53 @@
+---
+title: "ask"
+sidebarTitle: "ask"
+description: "Query the Chiplab firmware knowledge base tool. Ask about platform features, supported boards, or firmware development patterns and get answers grounded in Chiplab's documentation."
+---
+
+<Info>
+  This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself, just ask your agent in plain language and it takes care of the rest. This is a reference for the curious, not a set of instructions for you to follow.
+</Info>
+
+The `ask` tool gives your AI agent direct access to Chiplab's built-in knowledge base. Use it to look up how the platform works, understand the available tools, discover supported boards, and get guidance on uploading and running firmware. The assistant behind `ask` is purpose-built for Chiplab and will not answer questions unrelated to the platform.
+
+Exact parameters may evolve as the platform grows — call `ask({ "query": null })` to confirm the current shape.
+
+## Parameters
+
+<ParamField query="query" type="string | null">
+  A natural language question about Chiplab, or `null` to receive a platform overview describing what Chiplab does and listing all available tools.
+</ParamField>
+
+## Response
+
+<ResponseField name="(string)" type="string">
+  A plain-text answer from the Chiplab assistant. When relevant, the answer includes links to the specific documentation pages it drew from.
+</ResponseField>
+
+<Note>
+  Every Chiplab session should start with `ask({ "query": null })`. It gives your agent the context it needs before uploading or running firmware.
+</Note>
+
+## Example calls
+
+Get a platform overview (recommended first call):
+
+```json
+{ "query": null }
+```
+
+Ask how to upload a firmware artifact:
+
+```json
+{ "query": "How do I upload a firmware artifact?" }
+```
+
+Discover which boards are available for simulation:
+
+```json
+{ "query": "What boards does Chiplab support?" }
+```
+
+## How it works
+
+When you call `ask` with a `null` query, Chiplab returns a platform overview directly from its knowledge base. When you pass a natural language question, Chiplab routes it to an AI assistant with access to the most relevant sections of the shared [knowledge corpus](/introduction#knowledge-corpus) and composes a focused answer. The assistant is scoped exclusively to Chiplab usage topics, so every answer is grounded in accurate, up-to-date platform documentation.

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -3,51 +3,20 @@ title: "Tools Overview"
 description: "What your AI agent can do with Chiplab over MCP — illustrative, not a frozen contract."
 ---
 
-This page describes what your AI agent can do with Chiplab.
-You don't need to call anything yourself; it's reference material for the curious, not instructions to follow.
+This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself; it's reference material for the curious, not instructions to follow.
 
 <Warning>
-Chiplab's exact tool names, parameters, and response shapes evolve as the platform grows.
-Call `ask` with no arguments for the current, authoritative list — everything below is illustrative as of writing, not a fixed API contract.
+  Chiplab's exact tool names, parameters, and response shapes evolve as the platform grows. Call `ask` with no arguments for the current, authoritative list — everything below is illustrative as of writing, not a fixed API contract.
 </Warning>
 
-Chiplab exposes various capabilities to your agent over MCP: asking questions, and building, uploading, and running firmware.
-Your agent discovers the concrete tool names and schemas at connect time and calls them automatically; you don't need to know the exact shapes below to use Chiplab.
+Chiplab exposes various capabilities to your agent over MCP: asking questions, and building, uploading, and running firmware. Your agent discovers the concrete tool names and schemas at connect time and calls them automatically; you don't need to know the exact shapes below to use Chiplab.
 
-## Asking questions
+<CardGroup cols={2}>
+  <Card title="ask" icon="magnifying-glass" href="/tools/ask">
+    Query Chiplab's knowledge base for platform, tool, and firmware guidance.
+  </Card>
 
-Your agent can query Chiplab's built-in knowledge base for platform, tool, and firmware guidance.
-It's purpose-built for Chiplab topics and won't answer off-topic questions.
-
-Every Chiplab session should start with a `null`/empty query, which returns a platform overview pulled straight from the knowledge base, listing the current, complete set of tools.
-A natural-language query gets routed to an AI assistant scoped to Chiplab topics, grounded in the shared [knowledge corpus](/introduction#knowledge-corpus).
-
-```json
-{ "query": null }
-```
-```json
-{ "query": "How do I upload a firmware artifact?" }
-```
-```json
-{ "query": "What boards does Chiplab support?" }
-```
-
-## Building, uploading, and running firmware
-
-Your agent produces an ELF, uploads it, runs it on a chip-accurate virtual board, and reads back the result.
-Chiplab runs your firmware on a virtual instance of the target board via a simulation platform (today that means [Renode](https://renode.io), with [QEMU](https://www.qemu.org) and more planned) and returns the console output, no physical hardware required.
-
-Depending on what's live when you connect, this might be a single call or a small sequence (e.g. issuing an upload slot, uploading the artifact, then triggering the run).
-Your agent's MCP client discovers the exact tool calls and parameters live; ask Chiplab if you want to see them yourself.
-
-A typical run, illustrated as one step for simplicity:
-
-```json
-{ "artifact_id": "a1b2c3d4-...", "board_id": "stm32f4_discovery" }
-```
-Successful response, illustrated:
-```json
-{ "run_id": "run-xyz", "stdout": "Hello from STM32F4!\n", "stderr": "" }
-```
-
-<Tip>Not sure which board fits your firmware? Ask Chiplab about individual board specs; board recommendation tooling is on the way.</Tip>
+  <Card title="run" icon="play" href="/tools/run">
+    Build, upload, and run firmware on a chip-accurate virtual board.
+  </Card>
+</CardGroup>

--- a/docs/tools/overview.mdx
+++ b/docs/tools/overview.mdx
@@ -3,13 +3,16 @@ title: "Tools Overview"
 description: "What your AI agent can do with Chiplab over MCP — illustrative, not a frozen contract."
 ---
 
-This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself; it's reference material for the curious, not instructions to follow.
+This page describes what your AI agent can do with Chiplab.
+You don't need to call anything yourself; it's reference material for the curious, not instructions to follow.
 
 <Warning>
-  Chiplab's exact tool names, parameters, and response shapes evolve as the platform grows. Call `ask` with no arguments for the current, authoritative list — everything below is illustrative as of writing, not a fixed API contract.
+  Chiplab's exact tool names, parameters, and response shapes evolve as the platform grows.
+  Call `ask` with no arguments for the current, authoritative list — everything below is illustrative as of writing, not a fixed API contract.
 </Warning>
 
-Chiplab exposes various capabilities to your agent over MCP: asking questions, and building, uploading, and running firmware. Your agent discovers the concrete tool names and schemas at connect time and calls them automatically; you don't need to know the exact shapes below to use Chiplab.
+Chiplab exposes various capabilities to your agent over MCP: asking questions, and building, uploading, and running firmware.
+Your agent discovers the concrete tool names and schemas at connect time and calls them automatically; you don't need to know the exact shapes below to use Chiplab.
 
 <CardGroup cols={2}>
   <Card title="ask" icon="magnifying-glass" href="/tools/ask">

--- a/docs/tools/run.mdx
+++ b/docs/tools/run.mdx
@@ -1,16 +1,21 @@
 ---
 title: "run"
 sidebarTitle: "run"
-description: "Run compiled firmware on a chip-accurate virtual board with Chiplab. Get console output and pass/fail status without physical hardware."
+description: "Run compiled firmware on a chip-accurate virtual board with Chiplab. Get captured console output without physical hardware."
 ---
 
 <Info>
-  This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself, just ask your agent to run or test your firmware and it takes care of the rest. This is a reference for the curious, not a set of instructions for you to follow.
+  This page describes what your AI agent can do with Chiplab.
+  You don't need to call anything yourself, just ask your agent to run or test your firmware and it takes care of the rest.
+  This is a reference for the curious, not a set of instructions for you to follow.
 </Info>
 
-Chiplab can execute your firmware on a chip-accurate virtual board and return the console output, no physical hardware required. Chiplab runs your firmware on a virtual instance of the target board via a simulation platform (today that means [Renode](https://renode.io), with [QEMU](https://www.qemu.org) and more planned). Every supported board runs the same binary, the same peripherals, and the same interrupt timing as its physical counterpart, so what you see in Chiplab reflects what you'd see on real hardware.
+Chiplab can execute your firmware on a chip-accurate virtual board and return the console output, no physical hardware required.
+Chiplab runs your firmware on a virtual instance of the target board via a simulation platform (today that means [Renode](https://renode.io), with [QEMU](https://www.qemu.org) and more planned).
+Every supported board runs the same binary, the same peripherals, and the same interrupt timing as its physical counterpart, so what you see in Chiplab reflects what you'd see on real hardware.
 
-Depending on what's live when you connect, this might be a single call or a small sequence (e.g. issuing an upload slot, uploading the artifact, then triggering the run). Your agent's MCP client discovers the exact tool calls and parameters live; ask Chiplab if you want to see them yourself.
+Depending on what's live when you connect, this might be a single call or a small sequence (e.g. issuing an upload slot, uploading the artifact, then triggering the run).
+Your agent's MCP client discovers the exact tool calls and parameters live; ask Chiplab if you want to see them yourself.
 
 ## Parameters
 
@@ -29,11 +34,11 @@ Depending on what's live when you connect, this might be a single call or a smal
 </ResponseField>
 
 <ResponseField name="stdout" type="string">
-  All data written to standard output during the firmware simulation.
+  The captured UART/console output produced by your firmware during the simulation.
 </ResponseField>
 
 <ResponseField name="stderr" type="string">
-  All data written to standard error during the firmware simulation.
+  Simulator diagnostics emitted during the run (e.g. faults or simulation-level errors), separate from your firmware's own UART output.
 </ResponseField>
 
 ## Example calls
@@ -63,8 +68,10 @@ A successful response looks like this:
 
 ## Chip accuracy
 
-Chiplab's virtual boards are not generic CPU emulations. Each board runs your exact firmware binary against a faithful model of the target chip's peripherals, memory map, and interrupt controller, so results are directly comparable to real hardware outcomes.
+Chiplab's virtual boards are not generic CPU emulations.
+Each board runs your exact firmware binary against a faithful model of the target chip's peripherals, memory map, and interrupt controller, so results are directly comparable to real hardware outcomes.
 
 ## Knowledge corpus
 
-Every run deposits observed behavior into Chiplab's [knowledge corpus](/introduction#knowledge-corpus), indexed by chip family, failure pattern, and board configuration. Chiplab never collects your firmware code or binaries as part of this, only the chip-level behavior observed during the run.
+Every run deposits observed behavior into Chiplab's [knowledge corpus](/introduction#knowledge-corpus), indexed by chip family, failure pattern, and board configuration.
+Chiplab never collects your firmware code or binaries as part of this, only the chip-level behavior observed during the run.

--- a/docs/tools/run.mdx
+++ b/docs/tools/run.mdx
@@ -1,0 +1,70 @@
+---
+title: "run"
+sidebarTitle: "run"
+description: "Run compiled firmware on a chip-accurate virtual board with Chiplab. Get console output and pass/fail status without physical hardware."
+---
+
+<Info>
+  This page describes what your AI agent can do with Chiplab. You don't need to call anything yourself, just ask your agent to run or test your firmware and it takes care of the rest. This is a reference for the curious, not a set of instructions for you to follow.
+</Info>
+
+Chiplab can execute your firmware on a chip-accurate virtual board and return the console output, no physical hardware required. Chiplab runs your firmware on a virtual instance of the target board via a simulation platform (today that means [Renode](https://renode.io), with [QEMU](https://www.qemu.org) and more planned). Every supported board runs the same binary, the same peripherals, and the same interrupt timing as its physical counterpart, so what you see in Chiplab reflects what you'd see on real hardware.
+
+Depending on what's live when you connect, this might be a single call or a small sequence (e.g. issuing an upload slot, uploading the artifact, then triggering the run). Your agent's MCP client discovers the exact tool calls and parameters live; ask Chiplab if you want to see them yourself.
+
+## Parameters
+
+<ParamField body="artifact_id" type="string" required>
+  The identifier of the firmware binary to simulate. Your agent obtains this automatically before running.
+</ParamField>
+
+<ParamField body="board_id" type="string" required>
+  The slug identifying the virtual board to emulate. See [Supported Hardware](/hardware/boards) for the full list. Example values include `stm32f4_discovery` and `nrf52840_dk`.
+</ParamField>
+
+## Response
+
+<ResponseField name="run_id" type="string">
+  A unique identifier for this simulation run.
+</ResponseField>
+
+<ResponseField name="stdout" type="string">
+  All data written to standard output during the firmware simulation.
+</ResponseField>
+
+<ResponseField name="stderr" type="string">
+  All data written to standard error during the firmware simulation.
+</ResponseField>
+
+## Example calls
+
+Run a firmware binary on a target board:
+
+```json
+{
+  "artifact_id": "a1b2c3d4-...",
+  "board_id": "stm32f4_discovery"
+}
+```
+
+A successful response looks like this:
+
+```json
+{
+  "run_id": "run-xyz",
+  "stdout": "Hello from STM32F4!\n",
+  "stderr": ""
+}
+```
+
+<Tip>
+  Not sure which board fits your firmware? Ask Chiplab about individual board specs; board recommendation tooling is on the way.
+</Tip>
+
+## Chip accuracy
+
+Chiplab's virtual boards are not generic CPU emulations. Each board runs your exact firmware binary against a faithful model of the target chip's peripherals, memory map, and interrupt controller, so results are directly comparable to real hardware outcomes.
+
+## Knowledge corpus
+
+Every run deposits observed behavior into Chiplab's [knowledge corpus](/introduction#knowledge-corpus), indexed by chip family, failure pattern, and board configuration. Chiplab never collects your firmware code or binaries as part of this, only the chip-level behavior observed during the run.


### PR DESCRIPTION
docs(hardware): add OS/framework and board matrix details

Previously the Supported Hardware page only linked out to supported-boards.md on GitHub for the actual board list. Not every docs reader is comfortable browsing a GitHub repo, so mirror the OS/framework descriptions and the full board support matrix directly on the docs page.