### PR TITLE
chore: add glama.json to claim MCP server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["daniel-veecle", "veecle-sohyeon"]
+}


### PR DESCRIPTION
Adds `glama.json` so we can claim ownership of the Chiplab MCP server listing on [Glama.ai](https://glama.ai/mcp/servers) — required for org-owned repos since GitHub OAuth auto-claim only works for personal-account repos.

Schema only supports `maintainers`; display name/description/category are set via the Glama admin UI after claiming, not in this file.

Maintainers listed: `daniel-veecle`, `veecle-sohyeon` (current repo contributors).