### PR TITLE
CI: build the zephyr-os examples

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -54,3 +54,42 @@ jobs:
             (cd "${dir}" && make setup && make)
             echo "::endgroup::"
           done
+
+  zephyr:
+    name: Zephyr OS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # base-path is the west topdir, app-path the manifest repo inside it: init runs from
+      # examples/, whose manifest is zephyr-os/west.yml. Also installs the SDK, and fetches
+      # shallow (west update -o=--depth=1), as examples/zephyr-os/AGENTS.md documents.
+      - uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          base-path: examples
+          app-path: zephyr-os
+          toolchains: arm-zephyr-eabi
+      - name: Build every zephyr-os example
+        working-directory: examples/zephyr-os
+        run: |
+          # A board dir name is not its west board name, so the mapping is explicit. Keep in
+          # sync with the table in examples/zephyr-os/AGENTS.md; the check below fails the job
+          # on an unmapped board rather than skipping it.
+          boards="nrf52840-dk:nrf52840dk/nrf52840
+          stm32f4-discovery:stm32f4_disco
+          stm32f7-discovery:stm32f746g_disco
+          stm32h745-nucleo:nucleo_h745zi_q/stm32h745xx/m7
+          stm32l073-nucleo:nucleo_l073rz"
+          for cmakelists in $(git ls-files '*/CMakeLists.txt'); do
+            dir="${cmakelists%/CMakeLists.txt}"
+            case "${boards}" in
+              *"${dir}:"*) ;;
+              *) echo "::error::zephyr-os example '${dir}' has no west board mapping in .github/workflows/build-examples.yml"; exit 1 ;;
+            esac
+          done
+          while IFS=: read -r dir board; do
+            echo "::group::${dir}"
+            west build -b "${board}" -d "build/${dir}" "${dir}"
+            echo "::endgroup::"
+          done <<EOF
+          ${boards}
+          EOF

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -81,10 +81,8 @@ jobs:
           stm32l073-nucleo:nucleo_l073rz"
           for cmakelists in $(git ls-files '*/CMakeLists.txt'); do
             dir="${cmakelists%/CMakeLists.txt}"
-            case "${boards}" in
-              *"${dir}:"*) ;;
-              *) echo "::error::zephyr-os example '${dir}' has no west board mapping in .github/workflows/build-examples.yml"; exit 1 ;;
-            esac
+            printf '%s\n' "${boards}" | grep -q "^${dir}:" \
+              || { echo "::error::zephyr-os example '${dir}' has no west board mapping in .github/workflows/build-examples.yml"; exit 1; }
           done
           while IFS=: read -r dir board; do
             echo "::group::${dir}"

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -63,7 +63,7 @@ jobs:
       # base-path is the west topdir, app-path the manifest repo inside it: init runs from
       # examples/, whose manifest is zephyr-os/west.yml. Also installs the SDK, and fetches
       # shallow (west update -o=--depth=1), as examples/zephyr-os/AGENTS.md documents.
-      - uses: zephyrproject-rtos/action-zephyr-setup@v1
+      - uses: zephyrproject-rtos/action-zephyr-setup@be8136a8bba01580485d98b7ad2d32477c36a49a # v1.0.15
         with:
           base-path: examples
           app-path: zephyr-os

--- a/examples/zephyr-os/AGENTS.md
+++ b/examples/zephyr-os/AGENTS.md
@@ -48,7 +48,7 @@ Append `-o=--depth=1` to the `west update` line to skip history as well, taking 
 - **The workspace is shared, boards are not independently copy-pasteable.**
   west's T2 topdir (`.west/`) roots one level above wherever `west init -l .` runs, but the manifest's `import: path-prefix: zephyr-os` nests the pulled `zephyr-src/` and `modules/` trees back under this directory (`examples/zephyr-os/`) instead of leaving them in `examples/`.
   Every board dir sits under `examples/zephyr-os/`, so only one `west.yml` can ever be the active manifest for the whole directory.
-  Adding a board means adding its 3 files and a `west -b` table row — never a new `west.yml`.
+  Adding a board means adding its 3 files, a `west -b` table row, and an entry in the `boards` list of [`.github/workflows/build-examples.yml`](../../.github/workflows/build-examples.yml) (CI fails on an unmapped board) — never a new `west.yml`.
   The shared manifest's `import: name-allowlist` pulls only the HAL modules the boards here actually link (`cmsis`, `cmsis_6`, `hal_stm32`, `hal_nordic`) instead of every mainline HAL — a new board needs a new allowlist entry only if it needs a HAL not already listed.
   Pin `revision:` to a released tag, not a branch, for reproducible builds.
 - **The zephyr checkout is named `zephyr-src`, not `zephyr`.**


### PR DESCRIPTION
The zephyr-os examples have no CI coverage today; a board can break unnoticed until someone builds it by hand. This adds a `zephyr` job alongside the existing `rust` and `freertos` ones.

## Approach

Official `zephyrproject-rtos/action-zephyr-setup` on a plain `ubuntu-latest`. `base-path` is the west topdir and `app-path` the manifest repo inside it, matching the T2 layout: the manifest is `examples/zephyr-os/west.yml`, so `west init -l` runs from `examples/`. `app-path` must be a single path component, so the split is required rather than stylistic. The action already fetches shallow (`west update -o=--depth=1`, as `examples/zephyr-os/AGENTS.md` documents) and caches the SDK, pip and ccache itself.

A board directory name is not its west board name, so the mapping is explicit. A guard cross-checks it against the tracked `CMakeLists.txt` files and fails the job on an unmapped board instead of silently skipping it.

## Verification

Ran the build step verbatim under `bash -e` against a local workspace whose `.west/config` is identical to the one this job creates:
- all 5 boards build (ELFs 502–696 KB);
- unmapped board → exit 1 with `::error::… has no west board mapping`;
- failing build → aborts at the first failure.

Not verified: the job has never run on a GitHub runner — that is what this draft is for.

## Known caveats

- The action's pip-cache key hashes `examples/zephyr/scripts/requirements*.txt`, which cannot match our `zephyr-src/scripts/requirements-base.txt`, so that cache never invalidates. Installs still work (the project resolves by name). Both fixes are unattractive; left alone.
- Python comes from `ubuntu-latest` (3.12 today, fine for Zephyr 4.4). A future runner bump to a bleeding-edge Python could break build deps, per the warning in `examples/zephyr-os/AGENTS.md`. Pinning `actions/setup-python` to 3.13 would harden it; not done here to avoid shipping an unverified step.
