### PR TITLE
Examples: add threadx framework with STM32F4 Discovery example

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -39,3 +39,18 @@ jobs:
             (cd "${dir}" && make setup && make)
             echo "::endgroup::"
           done
+
+  threadx:
+    name: ThreadX
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install arm-none-eabi-gcc
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+      - name: Build every threadx example
+        run: |
+          for dir in examples/threadx/*/; do
+            echo "::group::${dir}"
+            (cd "${dir}" && make setup && make)
+            echo "::endgroup::"
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ build/
 
 # FreeRTOS: the kernel is fetched by `make setup` (pinned tag), never committed.
 examples/freertos/**/freertos-kernel/
+
+# ThreadX: the kernel is fetched by `make setup` (pinned tag), never committed.
+examples/threadx/**/threadx-kernel/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,8 +137,7 @@ Examples exist to validate Chiplab end-to-end, nothing more. Keep them minimal.
 - Cross-compilation happens on your side; Chiplab runs the ELF as-is.
 - Simulations are bounded to a fixed amount of virtual time; the captured output is
   the UART capture.
-- Boards are supported across the STM32 and Nordic nRF families, each with a
-  `bare-metal` and/or `embassy-rust` example. See
+- Boards are supported across the STM32 and Nordic nRF families. See
   [supported-boards.md](supported-boards.md) for the full board list, and
   call the discovery/help tool for the authoritative, up-to-date set.
 - To run your own firmware, build an ELF for the matching target and repeat the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,11 +14,12 @@ the [README](README.md) for the human-facing pitch.)
 This repo ships ready-to-run examples for **every supported board**, grouped by
 framework — currently `bare-metal` (vendor-HAL / direct-register), `embassy-rust`
 (the [Embassy](https://embassy.dev) async runtime), `zephyr-os` (C on the
-[Zephyr RTOS](https://zephyrproject.org), built with `west`), and `freertos` (C on the
-[FreeRTOS](https://www.freertos.org) kernel, built with `make`), each documented in
-`examples/<framework>/`. A user can open this repo, connect their
-agent to Chiplab, and say *"install Chiplab and test it on &lt;board&gt;"* — everything
-an agent needs to do that is below.
+[Zephyr RTOS](https://zephyrproject.org), built with `west`), `freertos` (C on the
+[FreeRTOS](https://www.freertos.org) kernel, built with `make`), and `threadx` (C on the
+[Eclipse ThreadX](https://github.com/eclipse-threadx/threadx) kernel, built with
+`make`), each documented in `examples/<framework>/`. A user can open this repo, connect
+their agent to Chiplab, and say *"install Chiplab and test it on &lt;board&gt;"* —
+everything an agent needs to do that is below.
 
 ## 1. Install / connect Chiplab
 

--- a/README.md
+++ b/README.md
@@ -83,12 +83,13 @@ Then sign in with `codex mcp login chiplab`.
 The contract is framework-agnostic: your agent **builds an ELF → uploads it → runs it on the target board → reads the captured UART output**.
 Runs return synchronously and are bounded to a fixed amount of virtual time.
 
-This repo ships a ready-to-run example for every supported board, grouped by framework — [`bare-metal`](examples/bare-metal) (Rust, vendor HAL), [`embassy-rust`](examples/embassy-rust) ([Embassy] async), [`zephyr-os`](examples/zephyr-os) ([Zephyr RTOS], C), and [`freertos`](examples/freertos) ([FreeRTOS], C).
+This repo ships a ready-to-run example for every supported board, grouped by framework — [`bare-metal`](examples/bare-metal) (Rust, vendor HAL), [`embassy-rust`](examples/embassy-rust) ([Embassy] async), [`zephyr-os`](examples/zephyr-os) ([Zephyr RTOS], C), [`freertos`](examples/freertos) ([FreeRTOS], C), and [`threadx`](examples/threadx) ([Eclipse ThreadX], C).
 The full board × framework matrix is in **[supported-boards.md](supported-boards.md)**.
 
 [Embassy]: https://embassy.dev
 [Zephyr RTOS]: https://zephyrproject.org
 [FreeRTOS]: https://www.freertos.org
+[Eclipse ThreadX]: https://github.com/eclipse-threadx/threadx
 
 Toolchain and build details live in each framework's directory (`examples/<framework>/README.md` for humans, `AGENTS.md` for agents) — your agent finds them on its own.
 Prefer building by hand?

--- a/docs/hardware/boards.mdx
+++ b/docs/hardware/boards.mdx
@@ -7,12 +7,13 @@ Chiplab boots a virtual instance of each supported chip on open simulation platf
 
 ## OS / frameworks
 
-Chiplab runs the same firmware pattern across four OS/framework combinations:
+Chiplab runs the same firmware pattern across five OS/framework combinations:
 
 - **`bare-metal`** — vendor-HAL / direct-register Rust firmware (no async runtime).
 - **`embassy-rust`** — the same firmware on the [Embassy](https://embassy.dev) async runtime.
 - **`zephyr-os`** — the same firmware on the [Zephyr RTOS](https://zephyrproject.org) (C, built with `west`).
 - **`freertos`** — the same firmware on the [FreeRTOS](https://www.freertos.org) kernel (C, built with `make` + `arm-none-eabi-gcc`).
+- **`threadx`** — the same firmware on the [Eclipse ThreadX](https://github.com/eclipse-threadx/threadx) kernel (C, built with `make` + `arm-none-eabi-gcc`).
 
 ## Board matrix
 
@@ -20,15 +21,15 @@ Every board Chiplab supports today, its chip, and its **board key** — the iden
 A checkmark links to a ready-to-run example for that OS/framework (— = not available yet).
 The canonical copy of this matrix lives in [supported-boards.md](https://github.com/veecle/chiplab/blob/main/supported-boards.md); if the two ever diverge, that file is authoritative.
 
-| Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` |
-|---|---|---|---|---|---|---|---|
-| STM32F4 Discovery | STM32F407 | STM32F4 | `stm32f4_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/freertos/stm32f4-discovery) |
-| STM32F7 Discovery | STM32F746 | STM32F7 | `stm32f7_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f7-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f7-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32f7-discovery) | — |
-| STM32F103 Blue Pill | STM32F103 | STM32F1 | `stm32f103_blue_pill` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f103-blue-pill) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f103-blue-pill) | — | — |
-| STM32WBA52 Nucleo | STM32WBA52 | STM32WBA | `stm32wba52_nucleo` | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32wba52-nucleo) | — | — |
-| STM32L073 Nucleo | STM32L073 | STM32L0 | `stm32l073_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32l073-nucleo) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32l073-nucleo) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32l073-nucleo) | — |
-| STM32H745 Nucleo | STM32H745 | STM32H7 | `stm32h745_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32h745-nucleo) | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32h745-nucleo) | — |
-| nRF52840 DK | nRF52840 | nRF52 | `nrf52840_dk` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/nrf52840-dk) | — |
+| Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` | `threadx` |
+|---|---|---|---|---|---|---|---|---|
+| STM32F4 Discovery | STM32F407 | STM32F4 | `stm32f4_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/freertos/stm32f4-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/threadx/stm32f4-discovery) |
+| STM32F7 Discovery | STM32F746 | STM32F7 | `stm32f7_discovery` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f7-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f7-discovery) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32f7-discovery) | — | — |
+| STM32F103 Blue Pill | STM32F103 | STM32F1 | `stm32f103_blue_pill` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32f103-blue-pill) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32f103-blue-pill) | — | — | — |
+| STM32WBA52 Nucleo | STM32WBA52 | STM32WBA | `stm32wba52_nucleo` | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32wba52-nucleo) | — | — | — |
+| STM32L073 Nucleo | STM32L073 | STM32L0 | `stm32l073_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32l073-nucleo) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/stm32l073-nucleo) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32l073-nucleo) | — | — |
+| STM32H745 Nucleo | STM32H745 | STM32H7 | `stm32h745_nucleo` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/stm32h745-nucleo) | — | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/stm32h745-nucleo) | — | — |
+| nRF52840 DK | nRF52840 | nRF52 | `nrf52840_dk` | [✓](https://github.com/veecle/chiplab/tree/main/examples/bare-metal/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/embassy-rust/nrf52840-dk) | [✓](https://github.com/veecle/chiplab/tree/main/examples/zephyr-os/nrf52840-dk) | — | — |
 
 Call Chiplab's discovery/help tool (`ask`) to confirm the current, authoritative set of boards — it may be ahead of what's listed here.
 

--- a/examples/threadx/AGENTS.md
+++ b/examples/threadx/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md — ThreadX (C)
+
+Framework-specific notes for the `threadx` examples.
+For the connect → upload → run contract see the [root AGENTS.md](../../AGENTS.md).
+
+## Toolchain & build
+
+Needs `arm-none-eabi-gcc` + `make` (macOS: `brew install --cask gcc-arm-embedded`; Debian/Ubuntu: `apt-get install gcc-arm-none-eabi`).
+The repo commits only the baseline app per board (`Makefile`, `src/main.c`, `src/tx_low_level.c`, `src/startup_<chip>.s`, `src/linker.ld`); the ThreadX kernel is fetched by `make setup` and gitignored, as is `build/`.
+Never commit the kernel or build output.
+
+| Board | Chip | ThreadX port | Board key |
+|---|---|---|---|
+| stm32f4-discovery | STM32F407 | `ports/cortex_m4/gnu` | `stm32f4_discovery` |
+
+```sh
+cd examples/threadx/<board>
+make setup     # shallow-clones eclipse-threadx/threadx @ the pinned tag (gitignored)
+make           # arm-none-eabi-gcc
+# ELF: build/hello-<board>.elf
+```
+
+## Conventions
+
+- One header comment line in `main.c` naming the board and UART.
+  No vendor HAL — drive the UART with direct register writes (see the bare-metal example for the same pattern).
+- Compile all of `common/src/*.c` (what ThreadX's own CMake build does) plus exactly the port sources listed in the port's `CMakeLists.txt`; `--gc-sections` drops the rest.
+  `tx_misra.S` and the standalone `tx_thread_interrupt_disable/restore.S` shims are not part of a normal build.
+- `main()` only initialises the UART and calls `tx_kernel_enter()`; objects are created in `tx_application_define()`.
+- Thread stacks and control blocks are static arrays, so no byte pool is needed and the `first_unused_memory` argument goes unused.
+  Keep it that way unless an example needs dynamic allocation.
+- Pin the kernel to a release tag in the `Makefile` (`KERNEL_TAG`), not a branch.
+- Clone from `eclipse-threadx/threadx` (MIT), never the archived `azure-rtos/threadx` (whose licence only permitted Microsoft-listed hardware).
+
+## Gotchas
+
+- **The app owns `_tx_initialize_low_level`** — unlike FreeRTOS, the Cortex-M ThreadX port does not ship one for your board.
+  It lives in the port's `example_build/` as reference only.
+  `src/tx_low_level.c` is this repo's C equivalent: it must set `_tx_initialize_unused_memory` and `_tx_thread_system_stack_ptr`, program `VTOR`, set the exception priorities, and start SysTick.
+- **`__RAM_segment_used_end__` is a port-example symbol, not a requirement** — the reference assembly derives first-unused-memory from it.
+  Our C version uses the linker script's `_ebss` instead, so the linker script doesn't need that symbol at all.
+- **Handler names** — the port defines `PendSV_Handler` (aliased `__tx_PendSVHandler`) in `tx_thread_schedule.S`; the vector table must reference it or the context switch never fires.
+  SysTick is the *application's* handler and must call `_tx_timer_interrupt()`.
+  SVCall is unused by this port.
+- **SVCall and PendSV must be lowest priority** (`0xFF` in SHPR2/SHPR3) — the port relies on the context switch tail-chaining after every other exception.
+- **FPU must be enabled in the reset handler** — the build uses the hard-float ABI (`-mfloat-abi=hard -mfpu=fpv4-sp-d16`, matching ThreadX's own build scripts), but ThreadX never touches `CPACR`, so the startup file grants CP10/CP11 access itself.
+- **Drain the UART** — block until the TX-complete flag is set before the thread sleeps, or the last bytes may not reach `stdout` before the 5 s window closes.
+- **Clock** — this example runs on HSI at 16 MHz (no PLL/HSE), matching the bare-metal and FreeRTOS STM32F4 examples.
+  `tx_low_level.c`'s SysTick reload and the USART `BRR` divisor both assume 16 MHz.
+  The simulated core runs faster than that, so the observed wall-clock print interval is shorter than `TX_TIMER_TICKS_PER_SECOND` implies — the FreeRTOS example shows the identical skew, so don't "fix" it by retuning the reload.
+- **The ELF is `build/hello-<board>.elf`** — upload that path.

--- a/examples/threadx/README.md
+++ b/examples/threadx/README.md
@@ -1,0 +1,36 @@
+# ThreadX (C)
+
+A minimal [Eclipse ThreadX](https://github.com/eclipse-threadx/threadx) application: one thread prints `Hello world!` over the UART, which Chiplab captures into `stdout`.
+ThreadX is just a kernel (scheduler + a CPU port), so the example pairs it with a tiny hand-written vendor layer — direct-register UART, startup, low-level kernel hooks, and linker script — instead of a full HAL.
+
+The repo commits only the **baseline app** (`src/`, `Makefile`); the ThreadX kernel is fetched by `make setup` (pinned to a release tag, MIT-licensed) and gitignored, along with the build output.
+You provide the toolchain.
+
+## Toolchain
+
+The Arm bare-metal GCC (`arm-none-eabi-gcc`) and `make`:
+
+```sh
+# macOS:  brew install --cask gcc-arm-embedded
+# Linux:  your distro's gcc-arm-none-eabi package
+```
+
+| Board | Chip | ThreadX port | Board key |
+|---|---|---|---|
+| stm32f4-discovery | STM32F407 | `ports/cortex_m4/gnu` | `stm32f4_discovery` |
+
+## Build
+
+```sh
+cd examples/threadx/stm32f4-discovery
+make setup     # shallow-clones eclipse-threadx/threadx @ the pinned tag (gitignored)
+make           # builds with arm-none-eabi-gcc
+# ELF: build/hello-stm32f4-discovery.elf
+```
+
+Then upload and run it per the [root README](../../README.md#how-it-works), using that ELF path and the board's key.
+
+Stuck, or want this on a board we don't cover yet?
+We'd love to hear from you — [open an issue](https://github.com/veecle/chiplab/issues/new/choose) and we're glad to help or add boards.
+Writing a new example?
+See [AGENTS.md](AGENTS.md) for conventions and gotchas.

--- a/examples/threadx/stm32f4-discovery/Makefile
+++ b/examples/threadx/stm32f4-discovery/Makefile
@@ -1,0 +1,72 @@
+# ThreadX hello-world on STM32F4 Discovery, built with arm-none-eabi-gcc.
+# `make setup` shallow-clones the ThreadX kernel (gitignored); `make` builds the ELF.
+
+PROJECT      := hello-stm32f4-discovery
+CROSS        := arm-none-eabi-
+CC           := $(CROSS)gcc
+SIZE         := $(CROSS)size
+
+KERNEL_REPO  := https://github.com/eclipse-threadx/threadx.git
+KERNEL_TAG   := v6.5.1.202602a_rel
+KERNEL_DIR   := threadx-kernel
+PORT_DIR     := $(KERNEL_DIR)/ports/cortex_m4/gnu
+
+BUILD_DIR    := build
+ELF          := $(BUILD_DIR)/$(PROJECT).elf
+
+ARCH_FLAGS   := -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
+INCLUDES     := -Isrc -I$(KERNEL_DIR)/common/inc -I$(PORT_DIR)/inc
+CFLAGS       := $(ARCH_FLAGS) $(INCLUDES) -Os -g3 -ffunction-sections -fdata-sections \
+                -Wall -Wextra
+LDFLAGS      := $(ARCH_FLAGS) -Tsrc/linker.ld -nostartfiles -Wl,--gc-sections \
+                -Wl,-Map=$(BUILD_DIR)/$(PROJECT).map --specs=nano.specs --specs=nosys.specs
+
+# The whole kernel core, as ThreadX's own CMake build does; --gc-sections drops
+# whatever this example doesn't call.
+C_SOURCES    := src/main.c \
+                src/tx_low_level.c \
+                $(wildcard $(KERNEL_DIR)/common/src/*.c)
+
+# Exactly the port sources ThreadX's CMakeLists lists (tx_misra.S and the standalone
+# interrupt disable/restore shims are not part of a normal build).
+ASM_SOURCES  := src/startup_stm32f407.s \
+                $(PORT_DIR)/src/tx_thread_context_restore.S \
+                $(PORT_DIR)/src/tx_thread_context_save.S \
+                $(PORT_DIR)/src/tx_thread_interrupt_control.S \
+                $(PORT_DIR)/src/tx_thread_schedule.S \
+                $(PORT_DIR)/src/tx_thread_stack_build.S \
+                $(PORT_DIR)/src/tx_thread_system_return.S \
+                $(PORT_DIR)/src/tx_timer_interrupt.S
+
+OBJECTS      := $(addprefix $(BUILD_DIR)/,$(C_SOURCES:.c=.o) \
+                $(patsubst %.S,%.o,$(patsubst %.s,%.o,$(ASM_SOURCES))))
+
+.PHONY: all setup clean check-kernel
+
+all: $(ELF)
+
+# One-time: fetch the kernel pinned to a release tag. Gitignored; never committed.
+setup:
+	@test -d $(KERNEL_DIR) || git clone --depth 1 --branch $(KERNEL_TAG) $(KERNEL_REPO) $(KERNEL_DIR)
+
+$(ELF): $(OBJECTS) | check-kernel
+	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
+	$(SIZE) $@
+
+$(BUILD_DIR)/%.o: %.c | check-kernel
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/%.o: %.S | check-kernel
+	@mkdir -p $(dir $@)
+	$(CC) $(ARCH_FLAGS) $(INCLUDES) -c $< -o $@
+
+$(BUILD_DIR)/%.o: %.s
+	@mkdir -p $(dir $@)
+	$(CC) $(ARCH_FLAGS) -c $< -o $@
+
+check-kernel:
+	@test -d $(KERNEL_DIR) || { echo "ThreadX kernel missing — run 'make setup' first."; exit 1; }
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/examples/threadx/stm32f4-discovery/Makefile
+++ b/examples/threadx/stm32f4-discovery/Makefile
@@ -65,8 +65,11 @@ $(BUILD_DIR)/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(CC) $(ARCH_FLAGS) -c $< -o $@
 
+# The second test catches `make setup all`: C_SOURCES is wildcarded at parse time, so a
+# kernel cloned by an earlier target in the same run contributes no objects to the link.
 check-kernel:
 	@test -d $(KERNEL_DIR) || { echo "ThreadX kernel missing — run 'make setup' first."; exit 1; }
+	@test -n "$(filter $(KERNEL_DIR)/%,$(C_SOURCES))" || { echo "Kernel was fetched after this make started — run 'make' again."; exit 1; }
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/examples/threadx/stm32f4-discovery/src/linker.ld
+++ b/examples/threadx/stm32f4-discovery/src/linker.ld
@@ -1,0 +1,61 @@
+/* STM32F407VG: 1 MB FLASH, 128 KB contiguous SRAM (the separate 64 KB CCM is
+ * deliberately excluded — ThreadX object and stack memory stays in one region). */
+
+ENTRY(Reset_Handler)
+
+MEMORY
+{
+    FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 1024K
+    RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+_estack = ORIGIN(RAM) + LENGTH(RAM);
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        . = ALIGN(4);
+        KEEP(*(.isr_vector))
+        . = ALIGN(4);
+    } > FLASH
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text)
+        *(.text*)
+        *(.rodata)
+        *(.rodata*)
+        . = ALIGN(4);
+    } > FLASH
+
+    .ARM.extab : { *(.ARM.extab*) } > FLASH
+    .ARM : { *(.ARM.exidx*) } > FLASH
+
+    _sidata = LOADADDR(.data);
+
+    .data :
+    {
+        . = ALIGN(4);
+        _sdata = .;
+        *(.data)
+        *(.data*)
+        . = ALIGN(4);
+        _edata = .;
+    } > RAM AT > FLASH
+
+    .bss :
+    {
+        . = ALIGN(4);
+        _sbss = .;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        _ebss = .;
+    } > RAM
+
+    /* Thread stacks and kernel objects are static arrays in .bss, so no heap or
+     * byte-pool region is needed; _ebss is handed to ThreadX as first-unused-memory. */
+}

--- a/examples/threadx/stm32f4-discovery/src/main.c
+++ b/examples/threadx/stm32f4-discovery/src/main.c
@@ -57,7 +57,7 @@ static void uart_write( const char *s )
         while( !( USART2_SR & USART_SR_TXE ) )
         {
         }
-        USART2_DR = ( uint32_t )( uint8_t ) * s++;
+        USART2_DR = ( uint32_t )( uint8_t )*s++;
     }
     /* Block until the last byte has fully shifted out, so the simulation window
      * doesn't close with bytes still sitting in the TX register. */

--- a/examples/threadx/stm32f4-discovery/src/main.c
+++ b/examples/threadx/stm32f4-discovery/src/main.c
@@ -1,0 +1,100 @@
+/* STM32F4 Discovery: a ThreadX thread prints "Hello world!" over USART2 (PA2/PA3). */
+
+#include <stdint.h>
+
+#include "tx_api.h"
+
+#define PERIPH_BASE          0x40000000UL
+#define AHB1_BASE            ( PERIPH_BASE + 0x00020000UL )
+#define APB1_BASE            ( PERIPH_BASE + 0x00000000UL )
+
+#define RCC_BASE             ( AHB1_BASE + 0x3800UL )
+#define RCC_AHB1ENR          ( *( volatile uint32_t * )( RCC_BASE + 0x30UL ) )
+#define RCC_APB1ENR          ( *( volatile uint32_t * )( RCC_BASE + 0x40UL ) )
+#define RCC_AHB1ENR_GPIOAEN  ( 1UL << 0 )
+#define RCC_APB1ENR_USART2EN ( 1UL << 17 )
+
+#define GPIOA_BASE           ( AHB1_BASE + 0x0000UL )
+#define GPIOA_MODER          ( *( volatile uint32_t * )( GPIOA_BASE + 0x00UL ) )
+#define GPIOA_AFRL           ( *( volatile uint32_t * )( GPIOA_BASE + 0x20UL ) )
+
+#define USART2_BASE          ( APB1_BASE + 0x4400UL )
+#define USART2_SR            ( *( volatile uint32_t * )( USART2_BASE + 0x00UL ) )
+#define USART2_DR            ( *( volatile uint32_t * )( USART2_BASE + 0x04UL ) )
+#define USART2_BRR           ( *( volatile uint32_t * )( USART2_BASE + 0x08UL ) )
+#define USART2_CR1           ( *( volatile uint32_t * )( USART2_BASE + 0x0CUL ) )
+#define USART_SR_TXE         ( 1UL << 7 )
+#define USART_SR_TC          ( 1UL << 6 )
+#define USART_CR1_UE         ( 1UL << 13 )
+#define USART_CR1_TE         ( 1UL << 3 )
+
+#define HELLO_STACK_WORDS    256
+#define HELLO_PRIORITY       1
+
+static TX_THREAD hello_thread;
+static ULONG hello_stack[ HELLO_STACK_WORDS ];
+
+static void uart_init( void )
+{
+    RCC_AHB1ENR |= RCC_AHB1ENR_GPIOAEN;
+    RCC_APB1ENR |= RCC_APB1ENR_USART2EN;
+
+    /* PA2/PA3 to AF mode (MODER=0b10), then AF7 (USART2) in the low AF register. */
+    GPIOA_MODER &= ~( ( 3UL << ( 2 * 2 ) ) | ( 3UL << ( 3 * 2 ) ) );
+    GPIOA_MODER |= ( 2UL << ( 2 * 2 ) ) | ( 2UL << ( 3 * 2 ) );
+    GPIOA_AFRL &= ~( ( 0xFUL << ( 2 * 4 ) ) | ( 0xFUL << ( 3 * 4 ) ) );
+    GPIOA_AFRL |= ( 7UL << ( 2 * 4 ) ) | ( 7UL << ( 3 * 4 ) );
+
+    /* PCLK1 = 16 MHz (HSI, no prescaler); BRR = fck / baud = 16e6 / 115200 = 139. */
+    USART2_BRR = 139;
+    USART2_CR1 = USART_CR1_UE | USART_CR1_TE;
+}
+
+static void uart_write( const char *s )
+{
+    while( *s )
+    {
+        while( !( USART2_SR & USART_SR_TXE ) )
+        {
+        }
+        USART2_DR = ( uint32_t )( uint8_t ) * s++;
+    }
+    /* Block until the last byte has fully shifted out, so the simulation window
+     * doesn't close with bytes still sitting in the TX register. */
+    while( !( USART2_SR & USART_SR_TC ) )
+    {
+    }
+}
+
+static void hello_entry( ULONG input )
+{
+    ( void ) input;
+    for( ;; )
+    {
+        uart_write( "Hello world!\n" );
+        tx_thread_sleep( TX_TIMER_TICKS_PER_SECOND );
+    }
+}
+
+/* ThreadX calls this from tx_kernel_enter() to create the application's objects.
+ * Stacks are static arrays, so the first-unused-memory pointer goes unused. */
+void tx_application_define( void *first_unused_memory )
+{
+    ( void ) first_unused_memory;
+
+    tx_thread_create( &hello_thread, "hello", hello_entry, 0,
+                      hello_stack, sizeof( hello_stack ),
+                      HELLO_PRIORITY, HELLO_PRIORITY,
+                      TX_NO_TIME_SLICE, TX_AUTO_START );
+}
+
+int main( void )
+{
+    uart_init();
+
+    tx_kernel_enter();
+
+    for( ;; )
+    {
+    }
+}

--- a/examples/threadx/stm32f4-discovery/src/startup_stm32f407.s
+++ b/examples/threadx/stm32f4-discovery/src/startup_stm32f407.s
@@ -1,0 +1,86 @@
+/* Minimal STM32F407 startup: vector table, reset handler (FPU enable, .data copy,
+ * .bss zero), and a default handler. The table is named `_vectors` because
+ * _tx_initialize_low_level() programs VTOR from that symbol. PendSV binds to the
+ * ThreadX port; SysTick binds to this example's handler in tx_low_level.c. */
+
+    .syntax unified
+    .cpu cortex-m4
+    .fpu fpv4-sp-d16
+    .thumb
+
+    .global _vectors
+    .global Reset_Handler
+
+    .section .isr_vector,"a",%progbits
+    .type _vectors, %object
+_vectors:
+    .word _estack
+    .word Reset_Handler
+    .word Default_Handler   /* NMI */
+    .word Default_Handler   /* HardFault */
+    .word Default_Handler   /* MemManage */
+    .word Default_Handler   /* BusFault */
+    .word Default_Handler   /* UsageFault */
+    .word 0
+    .word 0
+    .word 0
+    .word 0
+    .word Default_Handler   /* SVCall   — unused by the Cortex-M ThreadX port */
+    .word Default_Handler   /* DebugMon */
+    .word 0
+    .word PendSV_Handler    /* PendSV   — ThreadX port context switch */
+    .word SysTick_Handler   /* SysTick  — ThreadX kernel tick */
+    .size _vectors, . - _vectors
+
+    .section .text.Reset_Handler
+    .weak Reset_Handler
+    .type Reset_Handler, %function
+Reset_Handler:
+    ldr   sp, =_estack
+
+    /* Grant full access to CP10/CP11 — the firmware is built for the hard-float
+     * ABI, so the FPU must be on before any VFP instruction retires. */
+    ldr   r0, =0xE000ED88
+    ldr   r1, [r0]
+    orr   r1, r1, #(0xF << 20)
+    str   r1, [r0]
+    dsb
+    isb
+
+    /* Copy .data from its FLASH load address into RAM. */
+    ldr   r0, =_sdata
+    ldr   r1, =_edata
+    ldr   r2, =_sidata
+    movs  r3, #0
+    b     LoopCopyData
+CopyData:
+    ldr   r4, [r2, r3]
+    str   r4, [r0, r3]
+    adds  r3, r3, #4
+LoopCopyData:
+    adds  r4, r0, r3
+    cmp   r4, r1
+    bcc   CopyData
+
+    /* Zero .bss. */
+    ldr   r2, =_sbss
+    ldr   r4, =_ebss
+    movs  r3, #0
+    b     LoopZeroBss
+ZeroBss:
+    str   r3, [r2]
+    adds  r2, r2, #4
+LoopZeroBss:
+    cmp   r2, r4
+    bcc   ZeroBss
+
+    bl    main
+LoopForever:
+    b     LoopForever
+    .size Reset_Handler, . - Reset_Handler
+
+    .section .text.Default_Handler,"ax",%progbits
+    .type Default_Handler, %function
+Default_Handler:
+    b     Default_Handler
+    .size Default_Handler, . - Default_Handler

--- a/examples/threadx/stm32f4-discovery/src/tx_low_level.c
+++ b/examples/threadx/stm32f4-discovery/src/tx_low_level.c
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 
+#include "tx_api.h"
+
 #define SCB_VTOR              ( *( volatile uint32_t * )0xE000ED08UL )
 #define SCB_SHPR2             ( *( volatile uint32_t * )0xE000ED1CUL )
 #define SCB_SHPR3             ( *( volatile uint32_t * )0xE000ED20UL )
@@ -16,7 +18,6 @@
 #define SYSTICK_CTRL_CLKSOURCE ( 1UL << 2 )
 
 #define SYSTEM_CLOCK_HZ       16000000UL
-#define TICKS_PER_SECOND      100UL
 
 /* Defined by the linker script and the startup file. */
 extern uint32_t _estack;
@@ -43,7 +44,7 @@ void _tx_initialize_low_level( void )
     SCB_SHPR2 = 0xFF000000UL;
     SCB_SHPR3 = 0x40FF0000UL;
 
-    SYSTICK_LOAD = ( SYSTEM_CLOCK_HZ / TICKS_PER_SECOND ) - 1UL;
+    SYSTICK_LOAD = ( SYSTEM_CLOCK_HZ / TX_TIMER_TICKS_PER_SECOND ) - 1UL;
     SYSTICK_CTRL = SYSTICK_CTRL_CLKSOURCE | SYSTICK_CTRL_TICKINT | SYSTICK_CTRL_ENABLE;
 }
 

--- a/examples/threadx/stm32f4-discovery/src/tx_low_level.c
+++ b/examples/threadx/stm32f4-discovery/src/tx_low_level.c
@@ -1,0 +1,53 @@
+/* STM32F407 low-level hooks the ThreadX Cortex-M port expects the application to
+ * supply: kernel timer setup plus the SysTick handler that drives it. The port ships
+ * a reference implementation in ports/cortex_m4/gnu/example_build; this is the same
+ * contract written in C against this board's 16 MHz HSI clock. */
+
+#include <stdint.h>
+
+#define SCB_VTOR              ( *( volatile uint32_t * )0xE000ED08UL )
+#define SCB_SHPR2             ( *( volatile uint32_t * )0xE000ED1CUL )
+#define SCB_SHPR3             ( *( volatile uint32_t * )0xE000ED20UL )
+
+#define SYSTICK_CTRL          ( *( volatile uint32_t * )0xE000E010UL )
+#define SYSTICK_LOAD          ( *( volatile uint32_t * )0xE000E014UL )
+#define SYSTICK_CTRL_ENABLE   ( 1UL << 0 )
+#define SYSTICK_CTRL_TICKINT  ( 1UL << 1 )
+#define SYSTICK_CTRL_CLKSOURCE ( 1UL << 2 )
+
+#define SYSTEM_CLOCK_HZ       16000000UL
+#define TICKS_PER_SECOND      100UL
+
+/* Defined by the linker script and the startup file. */
+extern uint32_t _estack;
+extern uint32_t _ebss;
+extern const uint32_t _vectors[];
+
+/* Kernel-owned globals and the port's tick entry point. */
+extern void *_tx_thread_system_stack_ptr;
+extern void *_tx_initialize_unused_memory;
+void _tx_timer_interrupt( void );
+
+void _tx_initialize_low_level( void )
+{
+    /* Interrupts stay masked until the scheduler starts the first thread. */
+    __asm volatile ( "cpsid i" ::: "memory" );
+
+    _tx_initialize_unused_memory = ( void * ) &_ebss;
+    _tx_thread_system_stack_ptr = ( void * ) &_estack;
+
+    SCB_VTOR = ( uint32_t ) _vectors;
+
+    /* SVCall and PendSV must sit at the lowest priority (0xFF) for the port's
+     * context switch to be tail-chained after every other exception. */
+    SCB_SHPR2 = 0xFF000000UL;
+    SCB_SHPR3 = 0x40FF0000UL;
+
+    SYSTICK_LOAD = ( SYSTEM_CLOCK_HZ / TICKS_PER_SECOND ) - 1UL;
+    SYSTICK_CTRL = SYSTICK_CTRL_CLKSOURCE | SYSTICK_CTRL_TICKINT | SYSTICK_CTRL_ENABLE;
+}
+
+void SysTick_Handler( void )
+{
+    _tx_timer_interrupt();
+}

--- a/supported-boards.md
+++ b/supported-boards.md
@@ -15,21 +15,24 @@ OS/frameworks available today:
   (C, built with `west`).
 - **`freertos`** — the same `Hello world!` on the [FreeRTOS](https://www.freertos.org)
   kernel (C, built with `make` + `arm-none-eabi-gcc`).
+- **`threadx`** — the same `Hello world!` on the
+  [Eclipse ThreadX](https://github.com/eclipse-threadx/threadx) kernel (C, built with
+  `make` + `arm-none-eabi-gcc`).
 
 The matrix below lists every board, its board key, and the example that exists for
 each framework (— = not available yet). Toolchain and target details (e.g. the Rust
 target per board) live in each framework's doc under
 [`examples/<framework>/`](examples).
 
-| Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` |
-|---|---|---|---|---|---|---|---|
-| STM32F4 Discovery | STM32F407 | STM32F4 | `stm32f4_discovery` | [example](examples/bare-metal/stm32f4-discovery) | [example](examples/embassy-rust/stm32f4-discovery) | [example](examples/zephyr-os/stm32f4-discovery) | [example](examples/freertos/stm32f4-discovery) |
-| STM32F7 Discovery | STM32F746 | STM32F7 | `stm32f7_discovery` | [example](examples/bare-metal/stm32f7-discovery) | [example](examples/embassy-rust/stm32f7-discovery) | [example](examples/zephyr-os/stm32f7-discovery) | — |
-| STM32F103 Blue Pill | STM32F103 | STM32F1 | `stm32f103_blue_pill` | [example](examples/bare-metal/stm32f103-blue-pill) | [example](examples/embassy-rust/stm32f103-blue-pill) | — | — |
-| STM32WBA52 Nucleo | STM32WBA52 | STM32WBA | `stm32wba52_nucleo` | — | [example](examples/embassy-rust/stm32wba52-nucleo) | — | — |
-| STM32L073 Nucleo | STM32L073 | STM32L0 | `stm32l073_nucleo` | [example](examples/bare-metal/stm32l073-nucleo) | [example](examples/embassy-rust/stm32l073-nucleo) | [example](examples/zephyr-os/stm32l073-nucleo) | — |
-| STM32H745 Nucleo | STM32H745 | STM32H7 | `stm32h745_nucleo` | [example](examples/bare-metal/stm32h745-nucleo) | — | [example](examples/zephyr-os/stm32h745-nucleo) | — |
-| nRF52840 DK | nRF52840 | nRF52 | `nrf52840_dk` | [example](examples/bare-metal/nrf52840-dk) | [example](examples/embassy-rust/nrf52840-dk) | [example](examples/zephyr-os/nrf52840-dk) | — |
+| Board | Chip | Family | Board key | `bare-metal` | `embassy-rust` | `zephyr-os` | `freertos` | `threadx` |
+|---|---|---|---|---|---|---|---|---|
+| STM32F4 Discovery | STM32F407 | STM32F4 | `stm32f4_discovery` | [example](examples/bare-metal/stm32f4-discovery) | [example](examples/embassy-rust/stm32f4-discovery) | [example](examples/zephyr-os/stm32f4-discovery) | [example](examples/freertos/stm32f4-discovery) | [example](examples/threadx/stm32f4-discovery) |
+| STM32F7 Discovery | STM32F746 | STM32F7 | `stm32f7_discovery` | [example](examples/bare-metal/stm32f7-discovery) | [example](examples/embassy-rust/stm32f7-discovery) | [example](examples/zephyr-os/stm32f7-discovery) | — | — |
+| STM32F103 Blue Pill | STM32F103 | STM32F1 | `stm32f103_blue_pill` | [example](examples/bare-metal/stm32f103-blue-pill) | [example](examples/embassy-rust/stm32f103-blue-pill) | — | — | — |
+| STM32WBA52 Nucleo | STM32WBA52 | STM32WBA | `stm32wba52_nucleo` | — | [example](examples/embassy-rust/stm32wba52-nucleo) | — | — | — |
+| STM32L073 Nucleo | STM32L073 | STM32L0 | `stm32l073_nucleo` | [example](examples/bare-metal/stm32l073-nucleo) | [example](examples/embassy-rust/stm32l073-nucleo) | [example](examples/zephyr-os/stm32l073-nucleo) | — | — |
+| STM32H745 Nucleo | STM32H745 | STM32H7 | `stm32h745_nucleo` | [example](examples/bare-metal/stm32h745-nucleo) | — | [example](examples/zephyr-os/stm32h745-nucleo) | — | — |
+| nRF52840 DK | nRF52840 | nRF52 | `nrf52840_dk` | [example](examples/bare-metal/nrf52840-dk) | [example](examples/embassy-rust/nrf52840-dk) | [example](examples/zephyr-os/nrf52840-dk) | — | — |
 
 ## What simulation covers
 


### PR DESCRIPTION
Adds `threadx` as a fifth OS/framework, with one example: STM32F4 Discovery.

Deliberately a line-for-line sibling of `examples/freertos/stm32f4-discovery`

Will generalise later on.
